### PR TITLE
Create Reindex & Cache Flush Tasks

### DIFF
--- a/Task/Command/AbstractMagentoCommand.php
+++ b/Task/Command/AbstractMagentoCommand.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © Qoliber. All rights reserved.
+ *
+ * @category    Qoliber
+ * @package     Qoliber_CatalogGenerator
+ * @author      Jakub Winkler <jwinkler@qoliber.com>
+ */
+
+declare(strict_types=1);
+
+namespace Qoliber\CatalogGenerator\Task\Command;
+
+use Magento\Framework\Console\Cli;
+use Qoliber\CatalogGenerator\Api\Task\TaskInterface;
+
+abstract class AbstractMagentoCommand implements TaskInterface
+{
+    public function __construct(
+        protected readonly Cli $cli,
+    ) {
+    }
+
+    abstract public function runTask(): TaskInterface;
+}

--- a/Task/Command/CacheFlush.php
+++ b/Task/Command/CacheFlush.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © Qoliber. All rights reserved.
+ *
+ * @category    Qoliber
+ * @package     Qoliber_CatalogGenerator
+ * @author      Jakub Winkler <jwinkler@qoliber.com>
+ */
+
+declare(strict_types=1);
+
+namespace Qoliber\CatalogGenerator\Task\Command;
+
+use Magento\Framework\App\Cache\TypeListInterface;
+use Qoliber\CatalogGenerator\Api\Task\TaskInterface;
+
+class CacheFlush implements TaskInterface
+{
+    public function __construct(
+        private readonly TypeListInterface $cacheList,
+    ) {
+    }
+
+    public function runTask(): TaskInterface
+    {
+        foreach ($this->cacheList->getTypes() as $cacheId => $cache) {
+            $this->cacheList->cleanType($cacheId);
+        }
+
+        return $this;
+    }
+}

--- a/Task/Command/Reindex.php
+++ b/Task/Command/Reindex.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright © Qoliber. All rights reserved.
+ *
+ * @category    Qoliber
+ * @package     Qoliber_CatalogGenerator
+ * @author      Jakub Winkler <jwinkler@qoliber.com>
+ */
+
+declare(strict_types=1);
+
+namespace Qoliber\CatalogGenerator\Task\Command;
+
+use Qoliber\CatalogGenerator\Api\Task\TaskInterface;
+use Qoliber\CatalogGenerator\Task\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class Reindex extends AbstractMagentoCommand
+{
+    /**
+     * @return TaskInterface
+     * @throws \Exception
+     */
+    public function runTask(): TaskInterface
+    {
+        $input = new ArrayInput(['command' => 'indexer:reindex']);
+        $output = new BufferedOutput();
+
+        $this->cli->doRun($input, $output);
+
+        return $this;
+    }
+}

--- a/_samples/large.yml
+++ b/_samples/large.yml
@@ -61,3 +61,5 @@ entities:
       - 'product:generate_images'
       - 'product:generate_url_keys'
       - 'product:generate_urls'
+      - 'command:indexer:reindex'
+      - 'command:cache:flush'

--- a/_samples/medium.yml
+++ b/_samples/medium.yml
@@ -61,3 +61,5 @@ entities:
       - 'product:generate_images'
       - 'product:generate_url_keys'
       - 'product:generate_urls'
+      - 'command:indexer:reindex'
+      - 'command:cache:flush'

--- a/_samples/small.yml
+++ b/_samples/small.yml
@@ -60,3 +60,5 @@ entities:
       - 'product:generate_images'
       - 'product:generate_url_keys'
       - 'product:generate_urls'
+      - 'command:indexer:reindex'
+      - 'command:cache:flush'

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -55,6 +55,10 @@
                       xsi:type="object">Qoliber\CatalogGenerator\Task\Category\UrlAttributeGeneratorTask\Proxy</item>
                 <item name="category:generate_urls"
                       xsi:type="object">Qoliber\CatalogGenerator\Task\Category\UrlGeneratorTask\Proxy</item>
+                <item name="command:cache:flush"
+                      xsi:type="object">Qoliber\CatalogGenerator\Task\Command\CacheFlush\Proxy</item>
+                <item name="command:indexer:reindex"
+                      xsi:type="object">Qoliber\CatalogGenerator\Task\Command\Reindex\Proxy</item>
                 <item name="product:assign_to_categories"
                       xsi:type="object">Qoliber\CatalogGenerator\Task\Product\AssignToCategories\Proxy</item>
                 <item name="product:generate_url_keys"


### PR DESCRIPTION
# Description
These are mostly for convenience to save people having to run these steps manually after generating catalog entities.

Implementation input welcome, of course 🙂 
